### PR TITLE
KODO-6284 increase kOplogCompactEveryDeletedRecords to reduce disk write

### DIFF
--- a/src/rocks_record_store.h
+++ b/src/rocks_record_store.h
@@ -295,7 +295,7 @@ namespace mongo {
         // compact oplog every 30 min
         static const int kOplogCompactEveryMins = 30;
         // compact oplog every 500K deletes
-        static const int kOplogCompactEveryDeletedRecords = 500000;
+        static const int kOplogCompactEveryDeletedRecords = 10000000;
 
         // invariant: there is no live records earlier than _cappedOldestKeyHint. There might be
         // some records that are dead after _cappedOldestKeyHint.


### PR DESCRIPTION
默认的 500k 会频繁 compact，导致磁盘压力过大，考虑调高降低磁盘压力。线上业务观察磁盘读写能降低一半左右。